### PR TITLE
feat: Maintenance mode

### DIFF
--- a/src/commands/tcgAdmin/tcgAdmin.ts
+++ b/src/commands/tcgAdmin/tcgAdmin.ts
@@ -127,9 +127,12 @@ export const command: Command<ChatInputCommandInteraction> = {
             ephemeral: true,
           });
 
-          const maintenance = interaction.options.getBoolean("maintenance");
+          const maintenance = interaction.options.getBoolean(
+            "maintenance",
+            true
+          );
           try {
-            config.maintainance = true;
+            config.maintainance = maintenance;
             await interaction.editReply({
               content: `Maintenance mode is now ${
                 maintenance ? "enabled" : "disabled"

--- a/src/commands/tcgAdmin/tcgAdmin.ts
+++ b/src/commands/tcgAdmin/tcgAdmin.ts
@@ -8,6 +8,7 @@ import type { Command } from "../../types/command";
 import handleAchievementAutocomplete from "./achievementHandler/handleAchievementAutocomplete";
 import handleGrantAchievement from "./achievementHandler/handleGrantAchievement";
 import { ProgressBarBuilder } from "@src/tcg/formatting/percentBar";
+import config from "@src/config";
 
 export const command: Command<ChatInputCommandInteraction> = {
   data: new SlashCommandBuilder()
@@ -60,6 +61,18 @@ export const command: Command<ChatInputCommandInteraction> = {
             .setRequired(true)
             .setAutocomplete(true)
         )
+    )
+
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName("maintenance")
+        .setDescription("Manage maintenance mode")
+        .addBooleanOption((option) =>
+          option
+            .setName("maintenance")
+            .setDescription("Enable or disable maintenance mode")
+            .setRequired(true)
+        )
     ),
 
   async execute(interaction: ChatInputCommandInteraction) {
@@ -109,6 +122,35 @@ export const command: Command<ChatInputCommandInteraction> = {
               content: "Failed to build progress bar.",
             });
           }
+        case "maintenance":
+          await interaction.deferReply({
+            ephemeral: true,
+          });
+
+          const maintenance = interaction.options.getBoolean("maintenance");
+          try {
+            config.maintainance = true;
+            await interaction.editReply({
+              content: `Maintenance mode is now ${
+                maintenance ? "enabled" : "disabled"
+              }.`,
+            });
+
+            console.log(config.maintainance);
+          } catch (error) {
+            console.error("Error in maintenance mode:", error);
+            await interaction.editReply({
+              content: "Failed to set maintenance mode.",
+            });
+          }
+          break;
+        default:
+          await interaction.deferReply({
+            ephemeral: true,
+          });
+          await interaction.editReply({
+            content: "Invalid subcommand.",
+          });
       }
     } catch (error) {
       console.error(error);

--- a/src/commands/tcgChallenge/gameHandler/initiateChallengeRequest.ts
+++ b/src/commands/tcgChallenge/gameHandler/initiateChallengeRequest.ts
@@ -1,7 +1,8 @@
-import { ChatInputCommandInteraction } from "discord.js";
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
 import { GameMode, GameSettings } from "./gameSettings";
 import { handleOpponent } from "./utils/handleOpponent";
 import { buildChallengeButtonRespond } from "./utils/buildChallengeButtonRespond";
+import config from "@src/config";
 
 export async function initiateChallengeRequest(prop: {
   interaction: ChatInputCommandInteraction;
@@ -10,6 +11,14 @@ export async function initiateChallengeRequest(prop: {
   gamemode?: GameMode;
 }): Promise<void> {
   const { interaction, gameSettings, ranked, gamemode } = prop;
+  if (config.maintainance) {
+    await interaction.reply({
+      content:
+        "The game is currently under maintenance. New challenges are not allowed.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
 
   await interaction.deferReply();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,13 @@
 type Config = {
   debugMode?: boolean;
   logPrismaReqs?: boolean;
+  maintainance?: boolean;
 };
 
 const config: Config = {
   debugMode: false,
   logPrismaReqs: false,
+  maintainance: false,
 } satisfies Config;
 
 export default config;


### PR DESCRIPTION
## Maintenance mode
Use `/tcg-admin maintenance` to change the maintenance status of the bot.
During maintenance, new challenges cannot be created. Useful for when you need to restart the bot to push new changes but you have to wait for members to stop playing.
You can also use the `config.maintenance` value to do other stuff in the bot while in maintenance 

Idk why i made this, no one asked for it, but alas

![image](https://github.com/user-attachments/assets/de77c8c6-b537-469f-8ba8-ae6ba7a30a27)
