### PR TITLE
Fix 0 player leaderboard bug and enhance maintenance command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.5.0",
+        "@sapphire/discord.js-utilities": "^7.3.2",
         "cors": "^2.8.5",
         "discord.js": "^14.18.0",
         "dotenv": "^16.4.7",
@@ -712,6 +713,42 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@sapphire/discord-utilities": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@sapphire/discord-utilities/-/discord-utilities-3.4.4.tgz",
+      "integrity": "sha512-P7bCL5U2s+U5oy9OFpC4lr4Y0bGoNrSCPu2bgxP9AaqK90hcwpoLWWKouvGgaY9tCbUZmaf8E98/SlZZoakhAQ==",
+      "dependencies": {
+        "discord-api-types": "^0.37.114"
+      },
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/discord.js-utilities": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/discord.js-utilities/-/discord.js-utilities-7.3.2.tgz",
+      "integrity": "sha512-eEs6SjZghc7SlSRfirXzfJNy7sT9VxBtX32Zz33u8sxVq2X2/W6++klmDuIi6LSLrcsAlo9xWxcR+lL0pdaIEQ==",
+      "dependencies": {
+        "@sapphire/discord-utilities": "^3.4.4",
+        "@sapphire/duration": "^1.1.4",
+        "@sapphire/utilities": "^3.18.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.6.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/duration": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/duration/-/duration-1.2.0.tgz",
+      "integrity": "sha512-LxjOAFXz81WmrI8XX9YaVcAZDjQj/1p78lZCvkAWZB1nphOwz/D0dU3CBejmhOWx5dO5CszTkLJMNR0xuCK+Zg==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@sapphire/shapeshift": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
@@ -733,6 +770,14 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/utilities": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/utilities/-/utilities-3.18.2.tgz",
+      "integrity": "sha512-QGLdC9+pT74Zd7aaObqn0EUfq40c4dyTL65pFnkM6WO1QYN7Yg/s4CdH+CXmx0Zcu6wcfCWILSftXPMosJHP5A==",
+      "engines": {
+        "node": ">=v14.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.5.0",
+    "@sapphire/discord.js-utilities": "^7.3.2",
     "cors": "^2.8.5",
     "discord.js": "^14.18.0",
     "dotenv": "^16.4.7",

--- a/src/commands/tcgRanked/rankedHandlers/globalStats.ts
+++ b/src/commands/tcgRanked/rankedHandlers/globalStats.ts
@@ -1,7 +1,7 @@
 import prismaClient from "@prismaClient";
 import { GameMode } from "@src/commands/tcgChallenge/gameHandler/gameSettings";
 import { getLatestLadderReset } from "@src/util/db/getLatestLadderReset";
-import { ChatInputCommandInteraction } from "discord.js";
+import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
 import { Prisma } from "@prisma/client";
 import { capitalizeFirstLetter } from "@src/util/utils";
 import leaderboardEmbed from "./leaderboardEmbed";
@@ -9,6 +9,7 @@ import {
   LazyPaginatedMessage,
   type PaginatedMessageMessageOptionsUnion,
 } from "@sapphire/discord.js-utilities";
+import { characterNameToEmoji } from "@src/tcg/formatting/emojis";
 
 export type LadderRankWithPlayer = Prisma.LadderRankGetPayload<{
   include: { player: true };
@@ -74,6 +75,21 @@ export async function handleGlobalStats(
 
     return page;
   });
+
+  if (pages.length === 0) {
+    const leaderboardTitle = `${capitalizeFirstLetter(gamemode)} Ranked Global Leaderboard`;
+    const noPlayersFoundEmbed = new EmbedBuilder()
+      .setColor("Blurple")
+      .setTitle(leaderboardTitle)
+      .setDescription(
+        "No players found in this leaderboard. Maybe you could be the first one?"
+      );
+
+    await interaction.editReply({
+      embeds: [noPlayersFoundEmbed],
+    });
+    return;
+  }
 
   const paginated = new LazyPaginatedMessage({ pages });
   // you can change the message settings here

--- a/src/commands/tcgRanked/rankedHandlers/leaderboardEmbed.ts
+++ b/src/commands/tcgRanked/rankedHandlers/leaderboardEmbed.ts
@@ -1,3 +1,4 @@
+import { LazyPaginatedMessage } from "@sapphire/discord.js-utilities";
 import { CharacterName } from "@src/tcg/characters/metadata/CharacterName";
 import { characterNameToEmoji } from "@src/tcg/formatting/emojis";
 import { EmbedBuilder } from "discord.js";
@@ -22,13 +23,20 @@ export default async function leaderboardEmbed(props: {
   idsToPoints: { id: string; points: number }[];
   leaderboard: string;
   isCharacterLeaderboard: boolean;
+  page?: number;
+  pageSize?: number;
 }): Promise<EmbedBuilder> {
-  const { idsToPoints, leaderboard, isCharacterLeaderboard } = props;
-
+  const {
+    idsToPoints,
+    leaderboard,
+    isCharacterLeaderboard,
+    page = 1,
+    pageSize = 10,
+  } = props;
   const leaderboardTitle = `${isCharacterLeaderboard ? `${characterNameToEmoji[leaderboard as CharacterName]} ` : ""}${leaderboard} Global Leaderboard`;
   const userLines = idsToPoints.map((idtoPoint, index) => {
     const { id, points } = idtoPoint;
-    const rank = index + 1;
+    const rank = index + 1 + (page - 1) * pageSize;
     return `${getRankString(rank, id)}: ${points} pts`;
   });
 


### PR DESCRIPTION
Bot will no longer error out when there are no players in a leaderboard. Instead, it will send an embed like the following:
This resolves #41 
![image](https://github.com/user-attachments/assets/7b8e9043-0fcf-4d41-b300-dfbb67d14dfb)


Maintenance command now has two new options. Namely, `channel` and `send_message`.
`channel`: The channel to send the maintenance announcement in **(default: current channel)**
`send_message`: Whether to send the message or not **(default: true)**
This resolves #42 
![image](https://github.com/user-attachments/assets/cb7259a2-c6d8-4e52-94c0-68d99a5b25fd)
