### PR TITLE
migrate card actions to GameContext system

### DIFF
--- a/src/tcg/ability.ts
+++ b/src/tcg/ability.ts
@@ -1,6 +1,7 @@
 import { MessageCache } from "../tcgChatInteractions/messageCache";
 import Card from "./card";
 import Game from "./game";
+import { GameMessageContext } from "./gameContextProvider";
 
 export type Ability = {
   abilityName: string;
@@ -18,9 +19,7 @@ export type Ability = {
     card: Card
   ) => void;
   abilityOwnCardEffectWrapper?: (
-    game: Game,
-    characterIndex: number,
-    messageCache: MessageCache,
+    context: GameMessageContext,
     card: Card
   ) => void;
   abilityAfterOwnCardUse?: (

--- a/src/tcg/card.ts
+++ b/src/tcg/card.ts
@@ -1,7 +1,7 @@
-import { MessageCache } from "../tcgChatInteractions/messageCache";
 import { CharacterName } from "./characters/metadata/CharacterName";
 import { CardEmoji } from "./formatting/emojis";
 import Game from "./game";
+import { GameMessageContext } from "@src/tcg/gameContextProvider";
 
 export interface CardCosmetic {
   cardImageUrl?: string;
@@ -36,12 +36,7 @@ export type CardProps = {
   effects: number[];
   emoji?: CardEmoji;
   cosmetic?: CardCosmetic;
-  // TODO: change to a GameContext arg
-  cardAction: (
-    game: Game,
-    characterIndex: number,
-    messageCache: MessageCache
-  ) => void;
+  cardAction: (context: GameMessageContext) => void;
   // TODO: change to a GameContext arg
   conditionalTreatAsEffect?: (game: Game, characterIndex: number) => Card;
   empowerLevel?: number;
@@ -64,12 +59,7 @@ export default class Card implements CardProps {
   effects: number[];
   emoji: CardEmoji;
   cosmetic?: CardCosmetic | undefined;
-  // TODO: change to a GameContext arg
-  cardAction: (
-    game: Game,
-    characterIndex: number,
-    messageCache: MessageCache
-  ) => void;
+  cardAction: (context: GameMessageContext) => void;
   // TODO: change to a GameContext arg
   conditionalTreatAsEffect?: (game: Game, characterIndex: number) => Card;
   empowerLevel: number;

--- a/src/tcg/characters/characterData/characters/statsUtil/getStats.ts
+++ b/src/tcg/characters/characterData/characters/statsUtil/getStats.ts
@@ -1,4 +1,4 @@
-import { readFile, readFileSync, Stats } from "fs";
+import { readFileSync } from "fs";
 import path from "path";
 
 export function getStats() {

--- a/src/tcg/decks/DenkenDeck.ts
+++ b/src/tcg/decks/DenkenDeck.ts
@@ -11,7 +11,10 @@ const a_jab = new Card({
   description: ([def, spd, dmg]) => `DEF+${def}. SPD+${spd}. Deal ${dmg} DMG.`,
   emoji: CardEmoji.DENKEN_CARD,
   effects: [2, 1, 2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} jabbed with ${character.cosmetic.pronouns.possessive} fist.`,
@@ -39,7 +42,10 @@ const a_hook = new Card({
   description: ([spd, atk, dmg]) => `SPD+${spd}. ATK+${atk}. Deal ${dmg} DMG.`,
   emoji: CardEmoji.DENKEN_CARD,
   effects: [2, 1, 2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} threw out a hook!`,
@@ -71,7 +77,10 @@ const a_uppercut = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364978489035460708/GIF_0836074812.gif?ex=680c4b87&is=680afa07&hm=84fd66beff9352aba9c037ff66d2b0e69219b34c0e3c9c5e62edbf96dc62a0f8&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     const damage = this.calculateEffectValue(this.effects[2]);
     messageCache.push(
@@ -102,7 +111,10 @@ export const bareHandedBlock = new Card({
   emoji: CardEmoji.DENKEN_CARD,
   priority: 2,
   effects: [2, 8],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} raised his hands to prepare to block the opponent's attack!`,
@@ -141,15 +153,20 @@ export const a_waldgoseBase = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364217876323500123/GIF_0112106003.gif?ex=6808de67&is=68078ce7&hm=53339631d41657c84bff7858a0d4ca127e5dd726db694b68d34f5d833a75c8ba&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
-    const character = game.characters[characterIndex];
+  cardAction: function (this: Card, context) {
+    const {
+      game,
+      selfIndex: characterIndex,
+      self: character,
+      messageCache,
+    } = context;
 
     if (character.stats.stats.HP <= 0) {
       const jab = new Card({
         ...a_jab,
         empowerLevel: this.empowerLevel,
       });
-      jab.cardAction(game, characterIndex, messageCache);
+      jab.cardAction(context);
     } else {
       messageCache.push(
         `${character.name} whipped up a tornado!`,
@@ -222,14 +239,19 @@ export const a_daosdorgBase = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364218009102581871/GIF_4214490964.gif?ex=6808de87&is=68078d07&hm=dedf596f960aafe344c5eedec122d4dbd54c3b5c6f8b002b3cae75da891fdedf&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
-    const character = game.getCharacter(characterIndex);
+  cardAction: function (this: Card, context) {
+    const {
+      game,
+      selfIndex: characterIndex,
+      self: character,
+      messageCache,
+    } = context;
     if (character.stats.stats.HP <= 0) {
       const hook = new Card({
         ...a_hook,
         empowerLevel: this.empowerLevel,
       });
-      hook.cardAction(game, characterIndex, messageCache);
+      hook.cardAction(context);
     } else {
       messageCache.push(
         `${character.name} set the sky aflame.`,
@@ -298,14 +320,19 @@ export const a_catastraviaBase = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364218121669316608/GIF_1295476803.gif?ex=6808dea2&is=68078d22&hm=bdc2fd9b990ddf12a7cb0d6ad7b24dca2a24203773cd3896f0c53681dad85ed9&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
-    const character = game.characters[characterIndex];
+  cardAction: function (this: Card, context) {
+    const {
+      game,
+      selfIndex: characterIndex,
+      self: character,
+      messageCache,
+    } = context;
     if (character.stats.stats.HP <= 0) {
       const uppercut = new Card({
         ...a_uppercut,
         empowerLevel: this.empowerLevel,
       });
-      uppercut.cardAction(game, characterIndex, messageCache);
+      uppercut.cardAction(context);
     } else {
       messageCache.push(
         `${character.name} covered the sky in stars.`,
@@ -370,7 +397,10 @@ const elementaryDefensiveMagicBase = new Card({
   emoji: CardEmoji.DENKEN_CARD,
   priority: 2,
   effects: [20],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
 
     messageCache.push(
@@ -428,7 +458,10 @@ export const a_concentratedOffensiveMagicZoltraak = new Card({
   description: ([dmg]) => `HP-8. DMG ${dmg}.`,
   emoji: CardEmoji.DENKEN_CARD,
   effects: [14],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} sent forth a concentrated blast of Zoltraak.`,
@@ -453,7 +486,10 @@ export const thisIsNoPlaceToGiveUp = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364979223357296802/GIF_0406490421.gif?ex=680c4c36&is=680afab6&hm=cf5c0f9d7e3e14ec143a8b304c0d416868db25cb8de5a1f0b38cc4c7507df73d&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     const healingFirst = this.calculateEffectValue(this.effects[0]);
     const healingSecond = this.calculateEffectValue(this.effects[1]);

--- a/src/tcg/decks/FernDeck.ts
+++ b/src/tcg/decks/FernDeck.ts
@@ -16,7 +16,7 @@ export const a_fernZoltraak = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364355690780557404/GIF_4110295150.gif?ex=680a0781&is=6808b601&hm=4aa279af5d5b3ae167099775570328a51c55d8572aac6369a9748565b950f8a1&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(`${character.name} fired Zoltraak!`, TCGThread.Gameroom);
 
@@ -47,7 +47,7 @@ export const a_fernBarrage = new Card({
   cosmetic: {
     cardGif: "https://c.tenor.com/2RAJbNpiLI4AAAAd/tenor.gif",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} initiated her barrage!`,
@@ -133,7 +133,7 @@ const a_fernConcentratedZoltraakSnipe = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364357151111385098/GIF_1619936813.gif?ex=6809601d&is=68080e9d&hm=d315925c27f678c96ed238bcc826abd1c209e5e1dae651b445b7fa4760e0cf09&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} sniped at the opponent!`,
@@ -169,7 +169,7 @@ const disapprovingPout = new Card({
   cosmetic: {
     cardGif: "https://c.tenor.com/V1ad9v260E8AAAAd/tenor.gif",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     messageCache.push(
@@ -195,7 +195,7 @@ export const manaConcealment = new Card({
     `ATK+${atk}. DEF+${def}. Receive Priority+1 and additional 50% Pierce on attacks for next turn.`,
   emoji: CardEmoji.FERN_CARD,
   effects: [1, 2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} conceals ${character.cosmetic.pronouns.possessive} presence.`,
@@ -253,7 +253,7 @@ export const spellToCreateManaButterflies = new Card({
   },
   emoji: CardEmoji.FERN_CARD,
   effects: [6, 2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} conjured a field of mana butterflies.`,
@@ -307,7 +307,7 @@ export const commonDefensiveMagic = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364255159529767005/GIF_2894655091.gif?ex=68090120&is=6807afa0&hm=e81b702e207fea882babeffd4b376e8db66a1afac7b19191892b3e6e29a9772c&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} put up a common defensive spell.`,

--- a/src/tcg/decks/FrierenDeck.ts
+++ b/src/tcg/decks/FrierenDeck.ts
@@ -19,7 +19,7 @@ export const a_zoltraak = new Card({
   },
   tags: { PostAnalysis: 1 },
   effects: [8],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(`${character.name} fired Zoltraak!`, TCGThread.Gameroom);
 
@@ -41,7 +41,7 @@ export const fieldOfFlower = new Card({
   },
   emoji: CardEmoji.FLOWER_FIELD,
   effects: [5, 3],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} conjured a field of flowers!`,
@@ -87,7 +87,7 @@ export const a_judradjim = new Card({
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364225378952020029/GIF_1668382682.gif?ex=6808e564&is=680793e4&hm=2c769b1580a0639d7e83a046cad25ff641b839f91ab7c035b0ae844aae3b551c&",
   },
   effects: [13],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} sent forth Judradjim!`,
@@ -111,7 +111,7 @@ export const a_vollzanbel = new Card({
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364225342218309674/GIF_1142333080.gif?ex=6808e55b&is=680793db&hm=11bd4be532ecf85eab598b0533e6c5b747d9bb8483c74ec2a86f3ede0fb352aa&",
   },
   effects: [18],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} summoned Vollzanbel!`,
@@ -137,7 +137,7 @@ export const barrierMagicAnalysis = new Card({
   },
   effects: [2, 1, 1],
   tags: { Analysis: 2 },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} analyzed the opponent's defense!`,
@@ -172,7 +172,7 @@ export const demonMagicAnalysis = new Card({
   },
   effects: [2, 2, 1],
   tags: { Analysis: 2 },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} analyzed ancient demon's magic!`,
@@ -208,7 +208,7 @@ export const ordinaryDefensiveMagic = new Card({
   },
   effects: [20],
   priority: 2,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} cast ordinary defensive magic!`,
@@ -246,7 +246,7 @@ export const a_theHeightOfMagicBase = new Card({
   cardMetadata: { nature: Nature.Attack, signature: true },
   priority: 1,
   effects: [30],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} used "The Height of Magic"`,

--- a/src/tcg/decks/HimmelDeck.ts
+++ b/src/tcg/decks/HimmelDeck.ts
@@ -19,7 +19,7 @@ const a_FrierenStrikeTheirWeakpoint = new Card({
       "https://cdn.discordapp.com/attachments/1360969158623232300/1362092606695145482/GIF_1369578971.gif?ex=68086357&is=680711d7&hm=07c26c17a9a859865c2f107f8358b50df98cc49d49ed0daa2f659c6acb494f1e&",
   },
   effects: [7, 1],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     const isHimmel = character.name === CharacterName.Himmel;
@@ -79,7 +79,7 @@ const a_FrierenBackMeUp = new Card({
     `Opponent's DEF-${oppDef} for 4 turns. Frieren attacks for ${dmg} DMG. For the next 4 turn ends, Frieren attacks for an additional ${dmg} DMG.`,
   emoji: CardEmoji.HIMMEL_CARD,
   effects: [3, 2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     const isHimmel = character.name === CharacterName.Himmel;
@@ -142,7 +142,7 @@ export const a_FrierenNow = new Card({
   description: ([dmg]) => `DMG ${dmg}`,
   emoji: CardEmoji.HIMMEL_CARD,
   effects: [12],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     const isHimmel = character.name === CharacterName.Himmel;
     if (isHimmel) {
@@ -189,7 +189,7 @@ const a_EisenTheEnemysOpen = new Card({
     `Eisen winds up. DEF+${def} for 2 turns. At next turn's end, deal ${dmg} DMG.`,
   emoji: CardEmoji.HIMMEL_CARD,
   effects: [2, 10],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     const isHimmel = character.name === CharacterName.Himmel;
     if (isHimmel) {
@@ -254,7 +254,7 @@ const a_EisenCoverMyBack = new Card({
     `Eisen provides cover. DEF+${def} for 3 turns. Once per turn, when an opponent attacks, counter for ${dmg} DMG.`,
   emoji: CardEmoji.HIMMEL_CARD,
   effects: [3, 5],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     const isHimmel = character.name === CharacterName.Himmel;
     if (isHimmel) {
@@ -337,7 +337,7 @@ const eisenHoldTheLine = new Card({
   description: ([def]) => `Eisen holds the line. DEF+${def} for 4 turns.`,
   emoji: CardEmoji.HIMMEL_CARD,
   effects: [3],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     const isHimmel = character.name === CharacterName.Himmel;
     if (isHimmel) {
@@ -391,7 +391,7 @@ const heiterEmergency = new Card({
     `Heiter heals the party for ${heal}HP. At next turn's end, heal an additional ${heal} HP.`,
   emoji: CardEmoji.HIMMEL_CARD,
   effects: [5],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     const isHimmel = character.name === CharacterName.Himmel;
     if (isHimmel) {
@@ -438,7 +438,7 @@ const a_heiterThreeSpears = new Card({
     `Heiter casts Three Spears of the Goddess! At next 3 turn's end, deal ${heal} DMG.`,
   emoji: CardEmoji.HIMMEL_CARD,
   effects: [5],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     const isHimmel = character.name === CharacterName.Himmel;
     if (isHimmel) {
@@ -486,7 +486,7 @@ const heiterTrustYou = new Card({
     `Heiter supports the party. ATK+${atkSpd}, SPD+${atkSpd} for 4 turns.`,
   emoji: CardEmoji.HIMMEL_CARD,
   effects: [3],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     const isHimmel = character.name === CharacterName.Himmel;
     if (isHimmel) {
@@ -543,7 +543,7 @@ export const quickBlock = new Card({
   emoji: CardEmoji.HIMMEL_CARD,
   priority: 3,
   effects: [20],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} swiftly readied ${character.cosmetic.pronouns.possessive} sword to prepare for the opponent's attack!`,
@@ -574,7 +574,7 @@ const rally = new Card({
     `HP+${hp}. ATK+${stat}. DEF+${stat}. SPD+${stat}. An additional HP+${hp}, ATK+${stat}, DEF+${stat}, SPD+${stat} for each one of your active allies.`,
   emoji: CardEmoji.HIMMEL_CARD,
   effects: [2, 1],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     const isHimmel = character.name === CharacterName.Himmel;
     if (isHimmel) {
@@ -612,7 +612,7 @@ export const a_extremeSpeed = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361210956872421497/IMG_3122.gif?ex=6807d13e&is=68067fbe&hm=3ac9b147ffc7c93d02121986546428f4b36f0bb08a2c8bc526d5ba51df5a4bd6&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} dashed at the opponent!`,
@@ -637,7 +637,7 @@ export const a_realHeroSwing = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361777461620248576/GIF_1092034222.gif?ex=6807e697&is=68069517&hm=853f7d8910a4ab79010685a4399cd55c0af1f343295e0b2e04c49f829b54eee7&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const isHimmel = character.name === CharacterName.Himmel;
     messageCache.push(

--- a/src/tcg/decks/LaufenDeck.ts
+++ b/src/tcg/decks/LaufenDeck.ts
@@ -17,7 +17,7 @@ const a_staffStrike = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1365418943023681656/GIF_0570739142.gif?ex=681088bc&is=680f373c&hm=11d929f2c7b8bbc30b003a0d981cf02eb802b3651ba64f281ca1f5e0fa36b358&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} struck with ${character.cosmetic.pronouns.possessive} staff!`,
@@ -48,7 +48,7 @@ const a_staffBash = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1365418943023681656/GIF_0570739142.gif?ex=681088bc&is=680f373c&hm=11d929f2c7b8bbc30b003a0d981cf02eb802b3651ba64f281ca1f5e0fa36b358&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} bashed ${character.cosmetic.pronouns.possessive} staff!`,
@@ -79,7 +79,7 @@ export const a_whip = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1365419009721499718/GIF_3626022317.gif?ex=681088cc&is=680f374c&hm=838847fac81db2afc9448524255aceece7c3015a4af205b3014cd79ba565380c&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} turned ${character.cosmetic.pronouns.possessive} staff into a whip!`,
@@ -110,7 +110,7 @@ export const a_supersonicStrike = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1366373963789242388/GIF_0816288304-ezgif.com-optimize.gif?ex=6810b66a&is=680f64ea&hm=04b17a787656912d7075211221d149c8eaca57ca5ca916c27ab634fedaa75fb0&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} struck at supersonic speed!`,
@@ -137,7 +137,7 @@ export const hide = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1365422814097707120/GIF_3467240538.gif?ex=68108c57&is=680f3ad7&hm=afdbfcbce169548db1583e2f07027c57cf975b395500daee05e77e21a6b96b48&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} hid behind coverings!`,
@@ -167,7 +167,7 @@ const quickDodge = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1365419393307377684/GIF_1047990200.gif?ex=68108927&is=680f37a7&hm=f99fc20e4da10efce076e95809cf6f4349da36e3fdd8600003877c1589a37ea6&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(`${character.name} dodged away!`, TCGThread.Gameroom);
 
@@ -203,7 +203,7 @@ export const parry = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1365423837218472137/GIF_2008541989.gif?ex=68108d4b&is=680f3bcb&hm=886ee4f02a75662b1f11b3b64fbe46edada132bdffb20d022907d8df3ba15a33&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} switched to a parrying stance!`,
@@ -239,7 +239,7 @@ export const jilwer = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1363008456306725004/Jilwer.gif?ex=6807c3cb&is=6806724b&hm=21c109a6e16515d4ee652bb3d730625a7dda49bacb56ad286a0b303d39c26d72&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(`${character.name} used Jilwer!`, TCGThread.Gameroom);
 

--- a/src/tcg/decks/LinieDeck.ts
+++ b/src/tcg/decks/LinieDeck.ts
@@ -4,8 +4,7 @@ import TimedEffect from "../timedEffect";
 import CommonCardAction from "../util/commonCardActions";
 import { CardEmoji } from "../formatting/emojis";
 import { TCGThread } from "../../tcgChatInteractions/sendGameMessage";
-import { MessageCache } from "@src/tcgChatInteractions/messageCache";
-import Game from "../game";
+import { GameMessageContext } from "../gameContextProvider";
 
 export const imitate = new Card({
   title: "Imitate",
@@ -31,7 +30,7 @@ export const imitate = new Card({
         description: () => "No card to imitate. This move will fail.",
         effects: [],
         emoji: CardEmoji.LINIE_CARD,
-        cardAction: (_game, _characterIndex, messageCache: MessageCache) => {
+        cardAction: ({ messageCache }) => {
           messageCache.push(
             `No card to imitate. The move failed!`,
             TCGThread.Gameroom
@@ -53,7 +52,10 @@ export const adapt = new Card({
   cosmetic: {
     cardGif: "https://c.tenor.com/Dcc6-Rvkts8AAAAd/tenor.gif",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} adapts to the situation.`,
@@ -80,10 +82,9 @@ export const adapt = new Card({
 
 export const manaDetectionBaseCardAction = function (
   this: Card,
-  game: Game,
-  characterIndex: number,
-  messageCache: MessageCache
+  context: GameMessageContext
 ) {
+  const { game, selfIndex: characterIndex, messageCache } = context;
   const character = game.getCharacter(characterIndex);
   messageCache.push(
     `${character.name} detects the opponent's mana flow.`,
@@ -137,7 +138,10 @@ const parry = new Card({
   emoji: CardEmoji.LINIE_CARD,
   effects: [20],
   priority: 2,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} prepares to parry the opponent's attack.`,
@@ -170,7 +174,10 @@ export const a_erfassenAxe = new Card({
   cosmetic: {
     cardGif: "https://c.tenor.com/eUCHN11H4B4AAAAd/tenor.gif",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} recalls ${character.cosmetic.pronouns.possessive} Axe imitation.`,
@@ -192,7 +199,10 @@ export const a_erfassenJavelin = new Card({
   cosmetic: {
     cardGif: "https://c.tenor.com/zd9mOGFjT3IAAAAd/tenor.gif",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} recalls ${character.cosmetic.pronouns.possessive} Javelin imitation.`,
@@ -233,7 +243,10 @@ export const a_erfassenSword = new Card({
   cosmetic: {
     cardGif: "https://c.tenor.com/f4-8FBCgXg4AAAAd/tenor.gif",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} recalls ${character.cosmetic.pronouns.possessive} Sword imitation.`,
@@ -252,7 +265,10 @@ export const a_erfassenKnife = new Card({
     `HP-1. DMG ${dmg}. At the end of the next 2 turns, deal ${dmg}.`,
   emoji: CardEmoji.LINIE_CARD,
   effects: [2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} recalls ${character.cosmetic.pronouns.possessive} Knife throw imitation.`,

--- a/src/tcg/decks/SeinDeck.ts
+++ b/src/tcg/decks/SeinDeck.ts
@@ -18,7 +18,7 @@ export const a_trustInYourAllyFrierensZoltraak = new Card({
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361022845664104740/GIF_0907854706.gif?ex=6807cacc&is=6806794c&hm=c4c3d7908005bbcd23defb42f4c9b756135c8a5c1726330d0a52495998ec2c53&",
   },
   effects: [5],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     if (character.name === CharacterName.Sein) {
       messageCache.push(
@@ -52,7 +52,7 @@ export const a_trustInYourAllyFernsBarrage = new Card({
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361022927788834966/GIF_2294206836.gif?ex=6807cae0&is=68067960&hm=ca32887d358b3c43ad2d4c5618373b8cab1a11d0acdcc496a7203544936a9244&",
   },
   effects: [3],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     if (character.name === CharacterName.Sein) {
       messageCache.push(
@@ -108,7 +108,7 @@ const a_trustInYourAllyStarksLightningStrike = new Card({
   },
   effects: [7],
   priority: -1,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     if (character.name === CharacterName.Sein) {
       messageCache.push(
@@ -144,7 +144,7 @@ export const mugOfBeer = new Card({
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361017071886012681/GIF_3575013087.gif?ex=6807c56c&is=680673ec&hm=1e20739be8a75140974b9babb65729cf83c31d4f3d991bc35c90207fda41cd34&",
   },
   effects: [6, 2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} downed a mug of beer.`,
@@ -176,7 +176,7 @@ export const smokeBreak = new Card({
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361017954392866997/3.2.1.sein.gif?ex=6807c63e&is=680674be&hm=110488d337d86b35ac2b84cfec08e01c070a3ecb4563ccdfb3c1df602c5249f9&",
   },
   effects: [3, 2, 2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} took a smoke break.`,
@@ -211,7 +211,7 @@ export const awakening = new Card({
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361016482263208137/GIF_1188387197.gif?ex=6807c4df&is=6806735f&hm=f5ed7c521144db3412cf1a52b1417497950c1adf96d45301ff7421b5a75d8ca7&",
   },
   effects: [2, 1, 2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     messageCache.push(`${character.name} used Awakening!`, TCGThread.Gameroom);
 
@@ -242,7 +242,7 @@ export const poisonCure = new Card({
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361016416488390776/GIF_0966802288.gif?ex=6807c4d0&is=68067350&hm=2d09267ccc0505a949b0c57e6c9bb84fc99decb89d35637cadced435723f5904&",
   },
   effects: [10],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} applied a poison cure.`,
@@ -269,7 +269,7 @@ export const braceYourself = new Card({
   },
   priority: 2,
   effects: [20],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     if (character.name === CharacterName.Sein) {
       messageCache.push(
@@ -313,7 +313,7 @@ export const a_threeSpearsOfTheGoddess = new Card({
   },
   cardMetadata: { nature: Nature.Attack, signature: true },
   effects: [7],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} used Three Spears of the Goddess!`,

--- a/src/tcg/decks/SenseDeck.ts
+++ b/src/tcg/decks/SenseDeck.ts
@@ -12,7 +12,7 @@ export const a_hairWhip = new Card({
     `DEF+${def}. Afterwards, HP-4, DMG ${dmg}+DEF/4.`,
   effects: [3, 7],
   emoji: CardEmoji.PUNCH,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} whipped ${character.cosmetic.pronouns.possessive} hair!`,
@@ -34,7 +34,7 @@ export const sharpen = new Card({
   description: ([def, atk]) => `HP-1. DEF+${def}. ATK+${atk}.`,
   effects: [2, 2],
   emoji: CardEmoji.PUNCH,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} sharpened ${character.cosmetic.pronouns.possessive} hair drills!`,
@@ -60,7 +60,7 @@ export const rest = new Card({
   description: ([hp]) => `DEF-2 for 2 turns. Heal ${hp} HP`,
   effects: [10],
   emoji: CardEmoji.HEART,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(`${character.name} rests up.`, TCGThread.Gameroom);
 
@@ -95,7 +95,7 @@ export const a_pierce = new Card({
     `HP-7. DEF+${def}. Afterwards, DMG ${dmg} + (DEF/4). Pierces through 1/4 of the opponent's defense.`,
   effects: [2, 10],
   emoji: CardEmoji.PUNCH,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} pierced the opponent!`,
@@ -128,7 +128,7 @@ export const hairBarrier = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364942857307295905/GIF_0653594382.gif?ex=680b8198&is=680a3018&hm=368a1918766556e47cc2e4692113d174afa955d6f59f3206d2f0cb6269df4a34&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} surrounded ${character.cosmetic.pronouns.reflexive} in ${character.cosmetic.pronouns.possessive} hair barrier!`,
@@ -164,7 +164,7 @@ export const teaTime = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364949044656607232/GIF_0807192060.gif?ex=680b875b&is=680a35db&hm=ced86d0c723bc4d139d0012c97a29d89d6fad79d084e1607036211869d17b57e&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     messageCache.push(
@@ -193,7 +193,7 @@ export const teaParty = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364992405018902568/GIF_0507169428.gif?ex=680c587d&is=680b06fd&hm=dd2441c0af97bd72ee4c6ee262830ce4a418d07197f696bae7bb832202d6498c&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     messageCache.push(
@@ -223,7 +223,7 @@ export const a_piercingDrill = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364943023678427196/GIF_3233937113.gif?ex=680b81c0&is=680a3040&hm=07d5b41617b811cd069cc08f1de64d9966b4d03df7936844262be5f6ee25e0cb&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} used a piercing drill!`,

--- a/src/tcg/decks/SerieDeck.ts
+++ b/src/tcg/decks/SerieDeck.ts
@@ -11,24 +11,18 @@ import TimedEffect from "../timedEffect";
 import { fieldOfFlower } from "./FrierenDeck";
 import { CardEmoji } from "../formatting/emojis";
 import { TCGThread } from "../../tcgChatInteractions/sendGameMessage";
-import { MessageCache } from "@src/tcgChatInteractions/messageCache";
-import Game from "../game";
 import { ancientBarrierMagic } from "./utilDecks/serieSignature";
+import { GameMessageContext } from "../gameContextProvider";
 
 const useRandomCard = function (props: {
   cardPool: Card[];
   empowerLevel: number;
-  game: Game;
-  characterIndex: number;
-  messageCache: MessageCache;
+  context: GameMessageContext;
 }): Card {
-  const { cardPool, empowerLevel, game, characterIndex, messageCache } = props;
+  const { cardPool, empowerLevel, context } = props;
+  const { name, sendToGameroom } = context;
 
-  const character = game.getCharacter(characterIndex);
-  messageCache.push(
-    `${character.name} found an interesting magic.`,
-    TCGThread.Gameroom
-  );
+  sendToGameroom(`${name} found an interesting magic.`);
 
   const baseCard = cardPool[Math.floor(Math.random() * cardPool.length)];
   const newCard = new Card({
@@ -36,10 +30,7 @@ const useRandomCard = function (props: {
     empowerLevel,
   });
 
-  messageCache.push(
-    `${character.name} used **${newCard.getTitle()}**.`,
-    TCGThread.Gameroom
-  );
+  sendToGameroom(`${name} used **${newCard.getTitle()}**.`);
   return newCard;
 };
 
@@ -53,15 +44,13 @@ export const a_livingGrimoireOffenseCommon = new Card({
       "https://cdn.discordapp.com/attachments/1351391350398128159/1352873014785740800/Living_Grimoire_1.png?ex=6808772d&is=680725ad&hm=96a1d24a30264ade70debfc8ffe00506330d2b9ed559386e1a69a1c19bc647e9&",
   },
   effects: [],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, context) {
     const newCard = useRandomCard({
       cardPool: serie_offensiveMagic_common,
       empowerLevel: this.empowerLevel,
-      game,
-      characterIndex,
-      messageCache,
+      context,
     });
-    newCard.cardAction(game, characterIndex, messageCache);
+    newCard.cardAction(context);
   },
 });
 
@@ -75,15 +64,13 @@ export const a_livingGrimoireOffenseRare = new Card({
       "https://cdn.discordapp.com/attachments/1351391350398128159/1352873015121150022/Living_Grimoire1_1.png?ex=6808772d&is=680725ad&hm=903c0f575a5857d8527c631c5b4ef5fbf6ff9140ea44ea0a4f5ad7c6433a92a6&",
   },
   effects: [],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, context) {
     const newCard = useRandomCard({
       cardPool: serie_offensiveMagic_rare,
       empowerLevel: this.empowerLevel,
-      game,
-      characterIndex,
-      messageCache,
+      context,
     });
-    newCard.cardAction(game, characterIndex, messageCache);
+    newCard.cardAction(context);
   },
 });
 
@@ -97,15 +84,13 @@ export const a_livingGrimoireOffenseUnusual = new Card({
       "https://cdn.discordapp.com/attachments/1351391350398128159/1352873015825924147/Living_Grimoire2_1.png?ex=6808772e&is=680725ae&hm=63b0595c68a10b5d7c4246e4747f43fc61b292a95577b3c00b479ef11320ac58&",
   },
   effects: [],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, context) {
     const newCard = useRandomCard({
       cardPool: serie_offensiveMagic_unusual,
       empowerLevel: this.empowerLevel,
-      game,
-      characterIndex,
-      messageCache,
+      context,
     });
-    newCard.cardAction(game, characterIndex, messageCache);
+    newCard.cardAction(context);
   },
 });
 
@@ -119,15 +104,13 @@ export const a_livingGrimoireUtilityTactics = new Card({
       "https://cdn.discordapp.com/attachments/1351391350398128159/1352873014785740800/Living_Grimoire_1.png?ex=6808772d&is=680725ad&hm=96a1d24a30264ade70debfc8ffe00506330d2b9ed559386e1a69a1c19bc647e9&",
   },
   effects: [],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, context) {
     const newCard = useRandomCard({
       cardPool: serie_utilityMagic_tactics,
       empowerLevel: this.empowerLevel,
-      game,
-      characterIndex,
-      messageCache,
+      context,
     });
-    newCard.cardAction(game, characterIndex, messageCache);
+    newCard.cardAction(context);
   },
 });
 
@@ -141,15 +124,13 @@ export const a_livingGrimoireUtilityRecovery = new Card({
       "https://cdn.discordapp.com/attachments/1351391350398128159/1352873014785740800/Living_Grimoire_1.png?ex=6808772d&is=680725ad&hm=96a1d24a30264ade70debfc8ffe00506330d2b9ed559386e1a69a1c19bc647e9&",
   },
   effects: [],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, context) {
     const newCard = useRandomCard({
       cardPool: serie_utilityMagic_recovery,
       empowerLevel: this.empowerLevel,
-      game,
-      characterIndex,
-      messageCache,
+      context,
     });
-    newCard.cardAction(game, characterIndex, messageCache);
+    newCard.cardAction(context);
   },
 });
 
@@ -164,7 +145,10 @@ export const mock = new Card({
       "https://cdn.discordapp.com/attachments/1351391350398128159/1352873015502966825/Mock_1.png?ex=67df98ae&is=67de472e&hm=b4bfad8c4a548745a18660e2fcb39e7927661f269b17f9f8c73b66fa780f3d04&",
   },
   effects: [3, 2, 1],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} mocked the opponent.`,
@@ -199,7 +183,10 @@ export const basicDefensiveMagic = new Card({
   },
   effects: [20],
   priority: 2,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} casted a basic defensive magic!`,
@@ -235,7 +222,10 @@ export const unbreakableBarrier = new Card({
   },
   effects: [5, 5, 5],
   hpCost: 5,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} deployed an unbreakable barrier.`,

--- a/src/tcg/decks/StarkDeck.ts
+++ b/src/tcg/decks/StarkDeck.ts
@@ -17,7 +17,7 @@ const a_axeSwipe = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361125002761605140/IMG_3109.gif?ex=680829f1&is=6806d871&hm=ae00597c479d370662a52ae4f04cb024103354b0c758c483ff09946a0c1288ec&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} swiped ${character.cosmetic.pronouns.possessive} axe!`,
@@ -42,7 +42,7 @@ const offensiveStance = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361122664416018593/IMG_3106.gif?ex=680827c3&is=6806d643&hm=d6fdc758cc5b780bad809f674a6d3bf88f19ff038136bd96dca94e7c09ce18ed&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} took an offensive stance!`,
@@ -82,7 +82,7 @@ const defensiveStance = new Card({
   emoji: CardEmoji.STARK_CARD,
   effects: [2, 1],
   tags: { Resolve: 1 },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} took a defensive stance!`,
@@ -125,7 +125,7 @@ const jumboBerrySpecialBreak = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1360990957671153826/IMG_3099.gif?ex=680855da&is=6807045a&hm=7b11f297c0dc63b3bd8e9e19d7b7cb316001a389454bd05213d99686879f4f3c&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} chowed down on a Jumbo Berry Special!`,
@@ -175,7 +175,7 @@ export const block = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1360996196788867283/IMG_3102.gif?ex=68085abb&is=6807093b&hm=0602a1a0ef9278e1544911aa3e5b873617d0ab8cdd84c958c62e94f162bfe111&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} prepares to block an attack!`,
@@ -210,7 +210,7 @@ const concentration = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1360979639362781304/IMG_3087.gif?ex=68084b4f&is=6806f9cf&hm=98d20b75a63aca3116965b33fac4adac213feaefa4895cf0751976527dd483a0&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} concentrates on the battle.`,
@@ -234,7 +234,7 @@ const a_ordensSlashTechnique = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361187449522356324/IMG_3119.gif?ex=68086419&is=68071299&hm=f010c6a8f3b17eb25cdb15c8605dfb69ea06a323b0ca5aaed2484cce741ed4e6&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} used Orden's Slash Technique!`,
@@ -261,7 +261,7 @@ const fearBroughtMeThisFar = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1360983005946183957/IMG_3091.gif?ex=68084e72&is=6806fcf2&hm=5e9453189ccb1c31a4def06862e8dc7d2468c471eff0f8faa63d6288c8127c6c&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name}'s hands can't stop shaking, but ${character.name} is determined.`,
@@ -294,7 +294,7 @@ const a_eisensAxeCleave = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361191191533719602/IMG_3110.gif?ex=68086795&is=68071615&hm=e80ebb6c7098f7f020cc5a67819287df12f6ea5fa9427231382b6a8b026f3e47&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     if (character.name === CharacterName.Stark) {
       messageCache.push(
@@ -328,7 +328,7 @@ export const a_lightningStrike = new Card({
   cosmetic: {
     cardGif: "https://c.tenor.com/eHxDKoFxr2YAAAAC/tenor.gif",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
 
     if (character.adjustStat(-1 * this.hpCost, StatsEnum.HP)) {

--- a/src/tcg/decks/StilleDeck.ts
+++ b/src/tcg/decks/StilleDeck.ts
@@ -4,7 +4,6 @@ import { StatsEnum } from "../stats";
 import TimedEffect from "../timedEffect";
 import Rolls from "../util/rolls";
 import { CardEmoji } from "../formatting/emojis";
-import { MessageCache } from "../../tcgChatInteractions/messageCache";
 import { TCGThread } from "../../tcgChatInteractions/sendGameMessage";
 
 const a_peck = new Card({
@@ -16,23 +15,14 @@ const a_peck = new Card({
   effects: [5],
   cardAction: function (
     this: Card,
-    game,
-    characterIndex,
-    messageCache: MessageCache
+    { name, self, sendToGameroom, basicAttack }
   ) {
-    const character = game.characters[characterIndex];
-    messageCache.push(
-      `${character.name} pecked the opposition!`,
-      TCGThread.Gameroom
-    );
+    sendToGameroom(`${name} pecked the opposition!`);
 
-    character.adjustStat(-2, StatsEnum.SPD);
-    character.discardCard(Rolls.rollDAny(5));
-    character.drawCard();
-    CommonCardAction.commonAttack(game, characterIndex, {
-      damage: this.calculateEffectValue(this.effects[0]),
-      hpCost: 0,
-    });
+    self.adjustStat(-2, StatsEnum.SPD);
+    self.discardCard(Rolls.rollDAny(5));
+    self.drawCard();
+    basicAttack(0, 0);
   },
 });
 
@@ -42,7 +32,10 @@ const a_ironFeather = new Card({
   description: ([def, dmg]) => `SPD-3. DEF+${def}. DMG ${dmg}.`,
   emoji: CardEmoji.STILLE_CARD,
   effects: [1, 3],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} sharpened ${character.cosmetic.pronouns.possessive} feathers!`,
@@ -67,7 +60,10 @@ const hide = new Card({
   description: ([def]) => `SPD-3. DEF+${def}.`,
   emoji: CardEmoji.STILLE_CARD,
   effects: [2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} hid ${character.cosmetic.pronouns.reflexive} and flew to safety!`,
@@ -88,7 +84,10 @@ const roost = new Card({
   description: ([hp]) => `SPD-5 for 3 turns. DEF-3 for 2 turns. Heal ${hp}HP.`,
   emoji: CardEmoji.ROOST_CARD,
   effects: [5],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} landed on the ground.`,
@@ -144,7 +143,10 @@ export const deflect = new Card({
   emoji: CardEmoji.STILLE_CARD,
   effects: [20],
   priority: 2,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} prepares to deflect an attack!`,
@@ -179,7 +181,10 @@ const flyAway = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1361940199583780864/IMG_3171.gif?ex=6807d567&is=680683e7&hm=55cb8759a21dc4e1d852861c8856dd068b299cb289a109cd4be8cdd27cca4e2f&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(`${character.name} flew away!`, TCGThread.Gameroom);
 
@@ -211,7 +216,10 @@ export const a_geisel = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364971079096995840/GIF_0867566819.gif?ex=680b9be1&is=680a4a61&hm=af689691d54884d9f7df5a639c214146c59d7b3a9a6b0e8547fb41cf6b914c6c&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} called its fellow friends the Geisel for help!`,

--- a/src/tcg/decks/UbelDeck.ts
+++ b/src/tcg/decks/UbelDeck.ts
@@ -3,7 +3,6 @@ import CommonCardAction from "../util/commonCardActions";
 import { StatsEnum } from "../stats";
 import TimedEffect from "../timedEffect";
 import { CardEmoji } from "../formatting/emojis";
-import { MessageCache } from "../../tcgChatInteractions/messageCache";
 import { TCGThread } from "../../tcgChatInteractions/sendGameMessage";
 import { signatureMoves } from "./utilDecks/signatureMoves";
 import { a_malevolentShrine } from "./utilDecks/ubelSignature";
@@ -24,9 +23,7 @@ export const a_reelseiden = new Card({
   },
   cardAction: function (
     this: Card,
-    game,
-    characterIndex,
-    messageCache: MessageCache
+    { game, selfIndex: characterIndex, messageCache }
   ) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
@@ -58,9 +55,7 @@ export const a_cleave = new Card({
   },
   cardAction: function (
     this: Card,
-    game,
-    characterIndex,
-    messageCache: MessageCache
+    { game, selfIndex: characterIndex, messageCache }
   ) {
     const character = game.getCharacter(characterIndex);
     const pierceFactor = (character.additionalMetadata.pierceFactor ??= 0);
@@ -88,9 +83,7 @@ export const a_dismantle = new Card({
   },
   cardAction: function (
     this: Card,
-    game,
-    characterIndex,
-    messageCache: MessageCache
+    { game, selfIndex: characterIndex, messageCache }
   ) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
@@ -119,7 +112,10 @@ export const rushdown = new Card({
     cardGif:
       "https://media.discordapp.net/attachments/1360969158623232300/1364216562600509570/GIF_2060261812.gif?ex=6808dd2e&is=68078bae&hm=120ce38d9abf8a42357d0bd650f0e5c63da9ea2232bd5ceae2716ee67a2fb67f&=&width=1440&height=820",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} rushes towards the enemy!`,
@@ -173,7 +169,10 @@ const slowdown = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364216703541837844/GIF_2189012353.gif?ex=6808dd50&is=68078bd0&hm=644b405b52a67b684bda6bfff12ce2ffa99d091de554b967213e07aa87883a8d&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.characters[characterIndex];
     messageCache.push(
       `${character.name} takes cover to ponder the fleeting nature of her life.`,
@@ -233,7 +232,10 @@ export const defend = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364384151616094239/GIF_3928500915.gif?ex=680a2202&is=6808d082&hm=09e4cc493604c6e0be6f9a04263c49d93dd9a7d20bb18c78f6b58d1fd303c9b6&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} prepares to defend against an incoming attack!`,
@@ -269,7 +271,10 @@ export const sorganeil = new Card({
     cardGif:
       "https://cdn.discordapp.com/attachments/1360969158623232300/1364748769165447188/GIF_3534737554.gif?ex=680b7596&is=680a2416&hm=97e22820e064efed4dc8688572fffad891c01cdaac28df0e7a8e0ca77661521c&",
   },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
 
@@ -289,7 +294,7 @@ export const sorganeil = new Card({
       TCGThread.Gameroom
     );
 
-    let newTimedEffects: TimedEffect[] = [];
+    const newTimedEffects: TimedEffect[] = [];
     opponent.timedEffects.map((timedEffect) => {
       if (!timedEffect.removableBySorganeil) {
         newTimedEffects.push(timedEffect);
@@ -346,10 +351,9 @@ export const empathy = new Card({
         description: () => "Not enough time to empathize. This move will fail.",
         effects: [],
         emoji: CardEmoji.UBEL_CARD,
-        cardAction: (_game, _characterIndex, messageCache: MessageCache) => {
-          messageCache.push(
-            `${game.getCharacter(characterIndex).name} didn't get enough time to know ${game.getCharacter(1 - characterIndex).name} well enough!`,
-            TCGThread.Gameroom
+        cardAction: ({ name, opponent, sendToGameroom }) => {
+          sendToGameroom(
+            `${name} didn't get enough time to know ${opponent.name} well enough!`
           );
         },
         empathized: true,

--- a/src/tcg/decks/monsterDecks/AngryMimicDeck.ts
+++ b/src/tcg/decks/monsterDecks/AngryMimicDeck.ts
@@ -4,6 +4,7 @@ import { CardEmoji } from "../../formatting/emojis";
 import { StatsEnum } from "../../stats";
 import CommonCardAction from "../../util/commonCardActions";
 import { serie_offensiveMagic } from "../utilDecks/serieMagic";
+import { GameMessageContext } from "@src/tcg/gameContextProvider";
 
 // Regurgitate (x5) : use any offensive magic spell you stole from the mages you digested
 // Oh nom nom nom (x3) : 15 DMG, -2 DEF : restores an equal amount of HP compared to the damage
@@ -17,8 +18,11 @@ const a_regurgitate = new Card({
   description: () => `Use a random offensive spell at Empower level -2`,
   emoji: CardEmoji.SERIE_CARD,
   effects: [],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
-    const character = game.getCharacter(characterIndex);
+  cardAction: function (
+    this: Card,
+    context: GameMessageContext,
+  ) {
+	const { self: character, messageCache } = context;
     messageCache.push(
       `${character.name} regurgitated a spell it stole from a mage it munched on.`,
       TCGThread.Gameroom
@@ -37,7 +41,7 @@ const a_regurgitate = new Card({
       `${character.name} used **${newCard.getTitle()}**.`,
       TCGThread.Gameroom
     );
-    newCard.cardAction(game, characterIndex, messageCache);
+    newCard.cardAction(context);
   },
 });
 
@@ -48,7 +52,10 @@ const omNomNomNom = new Card({
     `HP-5. DMG ${dmg}. Restores HP by half of the move's dealt damage.`,
   emoji: CardEmoji.ENERGY,
   effects: [5],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} gobbles the opposition!`,
@@ -72,10 +79,14 @@ const mimic = new Card({
     `Use the card the opponent used last turn at this card's empower level -3.`,
   emoji: CardEmoji.LINIE_CARD,
   effects: [],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
-    const character = game.getCharacter(characterIndex);
-    const opponent = game.getCharacter(1 - characterIndex);
-
+  cardAction: function (this: Card, context) {
+    const {
+      game,
+      self: character,
+      selfIndex: characterIndex,
+      opponent,
+      messageCache,
+    } = context;
     messageCache.push(
       `${character.name} imitates ${opponent.name}'s last move.`,
       TCGThread.Gameroom
@@ -93,7 +104,7 @@ const mimic = new Card({
         `${character.name} uses ${newCard.getTitle()}`,
         TCGThread.Gameroom
       );
-      newCard.cardAction(game, characterIndex, messageCache);
+      newCard.cardAction(context);
     } else {
       messageCache.push(
         "There was no move to imitate. The move failed!",
@@ -109,7 +120,10 @@ const camouflage = new Card({
   description: ([def]) => `DEF + ${def}`,
   emoji: CardEmoji.SHIELD,
   effects: [4],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} camouflaged itself!`,
@@ -128,7 +142,10 @@ const a_callOfCthulhu = new Card({
   emoji: CardEmoji.ENERGY,
   effects: [30],
   cardMetadata: { nature: Nature.Attack, signature: true },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (
+    this: Card,
+    { game, selfIndex: characterIndex, messageCache }
+  ) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} heeds the call of Cthulhu.`,

--- a/src/tcg/decks/monsterDecks/CosmicTonDeck.ts
+++ b/src/tcg/decks/monsterDecks/CosmicTonDeck.ts
@@ -12,7 +12,7 @@ const madness = new Card({
   description: ([atk, def]) => `ATK+${atk}. DEF+${def}`,
   emoji: CardEmoji.HOURGLASS,
   effects: [3, 2],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const randomMessage = generateCustomRandomString(60, {
       useLowercase: true,
@@ -34,7 +34,7 @@ const earPiercingScream = new Card({
   description: ([def]) => `HP-2. Opponent's DEF-${def}.`,
   emoji: CardEmoji.ENERGY,
   effects: [3],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     const randomMessage = generateCustomRandomString(60, {
@@ -58,7 +58,7 @@ export const solitude = new Card({
   description: ([hp]) => `Heal for ${hp}.`,
   emoji: CardEmoji.HEART,
   effects: [12],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const randomMessage = generateCustomRandomString(30, {
       useLowercase: true,
@@ -78,7 +78,7 @@ export const a_curse = new Card({
   description: ([dmg]) => `HP-11. DMG ${dmg} at turn end for 5 turns.`,
   emoji: CardEmoji.PUNCH,
   effects: [5],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.characters[characterIndex];
     const randomMessage = generateCustomRandomString(80, {
       useNumbers: true,
@@ -117,7 +117,7 @@ const guiltTrip = new Card({
   description: ([def, spd]) => `Opp's DEF-${def}. Opp's SPD-${spd}`,
   emoji: CardEmoji.HOURGLASS,
   effects: [3, 3],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const randomMessage = generateCustomRandomString(100, {
       useUppercase: true,
       useSpecial: true,
@@ -140,7 +140,7 @@ export const a_killingMagic = new Card({
   description: ([dmg]) => `HP-10. DMG ${dmg}`,
   emoji: CardEmoji.PUNCH,
   effects: [15],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const randomMessage = generateCustomRandomString(90, {
       useUppercase: true,
       useSpecial: true,
@@ -165,7 +165,7 @@ export const a_solitaryPractice = new Card({
   emoji: CardEmoji.ENERGY,
   effects: [30],
   cardMetadata: { nature: Nature.Attack, signature: true },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(`solitary practice`, TCGThread.Gameroom);
     const endOfTurnDamage = this.calculateEffectValue(this.effects[0]);

--- a/src/tcg/decks/monsterDecks/FireGolemDeck.ts
+++ b/src/tcg/decks/monsterDecks/FireGolemDeck.ts
@@ -11,7 +11,7 @@ const a_flame = new Card({
   description: ([dmg]) => `HP-5. DMG ${dmg}.`,
   emoji: CardEmoji.PUNCH,
   effects: [12],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} sets the floor ablaze!`,
@@ -29,7 +29,7 @@ const a_burn = new Card({
   description: ([dmg, def]) => `HP-4. DMG ${dmg}. Opponent's DEF-${def}.`,
   emoji: CardEmoji.ENERGY,
   effects: [10, 3],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     messageCache.push(
@@ -55,7 +55,7 @@ const extinguish = new Card({
   emoji: CardEmoji.SHIELD,
   priority: 2,
   effects: [50],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} extinguishes itself!`,
@@ -87,7 +87,7 @@ const a_inferno = new Card({
   emoji: CardEmoji.ENERGY,
   effects: [30],
   cardMetadata: { nature: Nature.Attack, signature: true },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} lets out a gigantic inferno!`,

--- a/src/tcg/decks/monsterDecks/ShadowDragonDeck.ts
+++ b/src/tcg/decks/monsterDecks/ShadowDragonDeck.ts
@@ -12,7 +12,7 @@ const a_shadowImpalement = new Card({
   description: ([dmg]) => `HP-5. DMG ${dmg}.`,
   emoji: CardEmoji.PUNCH,
   effects: [10],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} dropped a shadow nail!`,
@@ -31,7 +31,7 @@ const camouflage = new Card({
     `ATK+${atk} for 3 turns. DEF+${def} for 3 turns.`,
   emoji: CardEmoji.HOURGLASS,
   effects: [3, 3],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} camouflaged ${character.cosmetic.pronouns.reflexive} in the shadow!`,
@@ -67,7 +67,7 @@ export const a_dragonfire = new Card({
   emoji: CardEmoji.PUNCH,
   effects: [10],
   cardMetadata: { nature: Nature.Attack, signature: true },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} breath forth a purple stream of flame!`,

--- a/src/tcg/decks/monsterDecks/StoneGeiselDeck.ts
+++ b/src/tcg/decks/monsterDecks/StoneGeiselDeck.ts
@@ -11,7 +11,7 @@ export const a_charge = new Card({
   description: ([dmg]) => `HP-5. DMG ${dmg}.`,
   emoji: CardEmoji.PUNCH,
   effects: [10],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(`${character.name} charged ahead!`, TCGThread.Gameroom);
 
@@ -26,7 +26,7 @@ const earPiercingScream = new Card({
   description: ([def]) => `HP-2. Opponent's DEF-${def}.`,
   emoji: CardEmoji.ENERGY,
   effects: [5],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     messageCache.push(
@@ -50,7 +50,7 @@ const hide = new Card({
   emoji: CardEmoji.SHIELD,
   effects: [20],
   priority: 2,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} made a quick retreat!`,
@@ -81,7 +81,7 @@ export const a_roomCollapse = new Card({
   emoji: CardEmoji.PUNCH,
   effects: [40],
   cardMetadata: { nature: Nature.Attack, signature: true },
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} collapsed the ceiling!`,

--- a/src/tcg/decks/monsterDecks/StoneGolemDeck.ts
+++ b/src/tcg/decks/monsterDecks/StoneGolemDeck.ts
@@ -12,7 +12,7 @@ export const a_rockTomb = new Card({
   description: ([dmg, spd]) => `HP-3. DMG ${dmg}. Opponent's SPD-${spd}`,
   emoji: CardEmoji.PUNCH,
   effects: [10, 5],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     messageCache.push(
@@ -36,7 +36,7 @@ const crystalize = new Card({
   emoji: CardEmoji.SHIELD,
   priority: 2,
   effects: [30],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} crystalizes ${character.cosmetic.pronouns.reflexive}!`,
@@ -72,7 +72,7 @@ const a_crusher = new Card({
   description: ([dmg, spd]) => `HP-5. DMG ${dmg}. Opponent's SPD-${spd}.`,
   emoji: CardEmoji.PUNCH,
   effects: [15, 7],
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     const opponent = game.getCharacter(1 - characterIndex);
     messageCache.push(

--- a/src/tcg/decks/utilDecks/defaultCard.ts
+++ b/src/tcg/decks/utilDecks/defaultCard.ts
@@ -1,7 +1,5 @@
-import { TCGThread } from "../../../tcgChatInteractions/sendGameMessage";
 import Card, { Nature } from "../../card";
 import { CardEmoji } from "../../formatting/emojis";
-import Game from "../../game";
 import { StatsEnum } from "../../stats";
 
 export default class DefaultCards {
@@ -13,29 +11,24 @@ export default class DefaultCards {
     effects: [],
     emoji: CardEmoji.RECYCLE,
     printEmpower: false,
-    cardAction: (game, characterIndex, messageCache) => {
-      const character = game.getCharacter(characterIndex);
-
-      character.adjustStat(1, StatsEnum.ATK);
-      character.adjustStat(1, StatsEnum.DEF);
-      character.adjustStat(1, StatsEnum.SPD);
+    cardAction: ({ self, selfIndex, name, sendToGameroom, game }) => {
+      self.adjustStat(1, StatsEnum.ATK);
+      self.adjustStat(1, StatsEnum.DEF);
+      self.adjustStat(1, StatsEnum.SPD);
 
       const handsIndicesDescending = Object.keys(
-        game.additionalMetadata.currentDraws[characterIndex]
+        game.additionalMetadata.currentDraws[selfIndex]
       )
         .map((stringIndex: string) => parseInt(stringIndex))
         .filter((a) => a < 6)
         .sort((a, b) => b - a);
       for (const index of handsIndicesDescending) {
-        character.discardCard(index);
-        character.drawCard();
+        self.discardCard(index);
+        self.drawCard();
       }
 
-      character.empowerHand();
-      messageCache.push(
-        `All cards in ${character.name}'s hand are empowered!`,
-        TCGThread.Gameroom
-      );
+      self.empowerHand();
+      sendToGameroom(`All cards in ${name}'s hand are empowered!`);
     },
   });
 
@@ -47,14 +40,12 @@ export default class DefaultCards {
     effects: [],
     printEmpower: false,
     emoji: CardEmoji.WAIT,
-    cardAction: (game, characterIndex, messageCache) => {
-      const character = game.getCharacter(characterIndex);
-      character.empowerHand();
-      messageCache.push(
-        `${character.name} waited it out! All cards in ${character.name}'s hand are empowered!`,
-        TCGThread.Gameroom
+    cardAction: ({ name, self, sendToGameroom }) => {
+      self.empowerHand();
+      sendToGameroom(
+        `${name} waited it out! All cards in ${name}'s hand are empowered!`
       );
-      character.adjustStat(10, StatsEnum.HP);
+      self.adjustStat(10, StatsEnum.HP);
     },
   });
 
@@ -66,12 +57,10 @@ export default class DefaultCards {
     effects: [],
     printEmpower: false,
     emoji: CardEmoji.WAIT,
-    cardAction: (game, characterIndex, messageCache) => {
-      const character = game.getCharacter(characterIndex);
-      character.empowerHand();
-      messageCache.push(
-        `${character.name} did nothing. All cards in ${character.name}'s hand are empowered.`,
-        TCGThread.Gameroom
+    cardAction: ({ self, name, sendToGameroom }) => {
+      self.empowerHand();
+      sendToGameroom(
+        `${name} did nothing. All cards in ${name}'s hand are empowered.`
       );
     },
   });
@@ -83,12 +72,9 @@ export default class DefaultCards {
     effects: [],
     printEmpower: false,
     emoji: CardEmoji.RANDOM,
-    cardAction: (game: Game, characterIndex, messageCache) => {
-      const character = game.getCharacter(characterIndex);
-      messageCache.push(
-        `${character.name} forfeited the game!`,
-        TCGThread.Gameroom
-      );
+	priority: 99,
+    cardAction: ({ game, selfIndex: characterIndex, name, sendToGameroom }) => {
+      sendToGameroom(`${name} forfeited the game!`);
       game.additionalMetadata.forfeited[characterIndex] = true;
     },
   });

--- a/src/tcg/decks/utilDecks/serieSignature.ts
+++ b/src/tcg/decks/utilDecks/serieSignature.ts
@@ -18,7 +18,7 @@ export const ancientBarrierMagic = new Card({
   cardMetadata: { nature: Nature.Util, signature: true },
   effects: [5, 5, 5],
   hpCost: 5,
-  cardAction: function (this: Card, game, characterIndex, messageCache) {
+  cardAction: function (this: Card, { game, selfIndex: characterIndex, messageCache }) {
     const character = game.getCharacter(characterIndex);
     messageCache.push(
       `${character.name} expanded an ancient barrier magic.`,

--- a/src/tcg/decks/utilDecks/ubelSignature.ts
+++ b/src/tcg/decks/utilDecks/ubelSignature.ts
@@ -1,7 +1,6 @@
 import Card, { Nature } from "../../card";
 import CommonCardAction from "../../util/commonCardActions";
 import { CardEmoji } from "../../formatting/emojis";
-import { MessageCache } from "../../../tcgChatInteractions/messageCache";
 import { TCGThread } from "../../../tcgChatInteractions/sendGameMessage";
 
 export const a_malevolentShrine = new Card({
@@ -18,9 +17,7 @@ export const a_malevolentShrine = new Card({
   hpCost: 11,
   cardAction: function (
     this: Card,
-    game,
-    characterIndex,
-    messageCache: MessageCache
+    { game, selfIndex: characterIndex, messageCache }
   ) {
     const character = game.getCharacter(characterIndex);
     const pierceFactor = (character.additionalMetadata.pierceFactor ??= 0);

--- a/src/tcg/gameContextProvider.ts
+++ b/src/tcg/gameContextProvider.ts
@@ -29,7 +29,7 @@ export default function gameContextProvider(
   characterIndex: number
 ) {
   const self = game.getCharacter(characterIndex);
-  const opponent = game.getCharacter(characterIndex - 1);
+  const opponent = game.getCharacter(1 - characterIndex);
 
   const calcEffect = (effectIndex: number) => {
     return calculateEffectValue(this.effects[effectIndex], this.empowerLevel);

--- a/src/tcg/gameContextProvider.ts
+++ b/src/tcg/gameContextProvider.ts
@@ -7,6 +7,7 @@ import Card from "@src/tcg/card";
 import CommonCardAction from "./util/commonCardActions";
 
 export type GameContext = ReturnType<typeof gameContextProvider>;
+export type GameMessageContext = ReturnType<typeof gameAndMessageContext>;
 
 // adapted from Card.ts
 const EMPOWER_BOOST = 0.1;
@@ -20,14 +21,12 @@ const calculateEffectValue = (baseValue: number, empowerLevel: number) => {
  * @param {Card} this - A card instance
  * @param {Game} game - The game instance
  * @param {number} characterIndex - The index of the character using the card or effect
- * @param {MessageCache} messageCache - The message cache instance
  * @returns The GameContext object with context-specific methods and properties for use in game actions
  */
 export default function gameContextProvider(
   this: Card,
   game: Game,
-  characterIndex: number,
-  messageCache: MessageCache
+  characterIndex: number
 ) {
   const self = game.getCharacter(characterIndex);
   const opponent = game.getCharacter(characterIndex - 1);
@@ -81,10 +80,6 @@ export default function gameContextProvider(
   const flatOpponentStat = changeStat.bind(null, opponent);
   const opponentStat = changeStatWithEmpower.bind(null, opponent);
 
-  const sendToGameroom = (message: string) => {
-    messageCache.push(message, TCGThread.Gameroom);
-  };
-
   return {
     // self properties
     self,
@@ -115,9 +110,29 @@ export default function gameContextProvider(
 
     // game
     game,
+  };
+}
 
+function messageContext(messageCache: MessageCache) {
+  const sendToGameroom = (message: string) => {
+    messageCache.push(message, TCGThread.Gameroom);
+  };
+
+  return {
     // thread messaging
-    messageCache,
     sendToGameroom,
+    messageCache,
+  };
+}
+
+export function gameAndMessageContext(
+  this: Card,
+  game: Game,
+  messageCache: MessageCache,
+  characterIndex: number
+) {
+  return {
+    ...gameContextProvider.call(this, game, characterIndex),
+    ...messageContext(messageCache),
   };
 }

--- a/src/tcgMain.ts
+++ b/src/tcgMain.ts
@@ -20,6 +20,7 @@ import { printCharacter } from "./tcgChatInteractions/printCharacter";
 import TimedEffect from "./tcg/timedEffect";
 import { playSelectedMove } from "./tcgChatInteractions/playSelectedMove";
 import { CharacterName } from "./tcg/characters/metadata/CharacterName";
+import { gameAndMessageContext } from "@src/tcg/gameContextProvider";
 
 const TURN_LIMIT = 50;
 
@@ -351,20 +352,22 @@ export const tcgMain = async (
             TCGThread.Gameroom
           );
           if (card.cosmetic?.cardGif) {
+			// look into discord's new media components from components v2 for this
             messageCache.push(
               `[⠀](${card.cosmetic?.cardGif})`,
               TCGThread.Gameroom
             );
           }
+          const context = gameAndMessageContext.call(
+            card,
+            game,
+            messageCache,
+            characterIndex
+          );
           if (character.ability.abilityOwnCardEffectWrapper) {
-            character.ability.abilityOwnCardEffectWrapper(
-              game,
-              characterIndex,
-              messageCache,
-              card
-            );
+            character.ability.abilityOwnCardEffectWrapper(context, card);
           } else {
-            card.cardAction?.(game, characterIndex, messageCache);
+            card.cardAction?.(context);
           }
           if (opponentCharacter.ability.abilityAfterOpponentsMoveEffect) {
             opponentCharacter.ability.abilityAfterOpponentsMoveEffect(


### PR DESCRIPTION
 migrate card actions to GameContext system
 
Other Changes
- Factor message cache into separate function as it works by itself
- Fix getting opponent in context
- Forfeit is priority 99
- Change main game loop to handle new card actions
- Also migrate `abilityOwnCardEffectWrapper` specifically because it was pretty intertwined with Ubel's logic