### PR TITLE
Rounded Laufen's speed diff to 2dp

### DIFF
--- a/src/tcg/characters/characterData/characters/Laufen.ts
+++ b/src/tcg/characters/characterData/characters/Laufen.ts
@@ -57,9 +57,10 @@ const Laufen = new CharacterData({
 
       const spdDiff = character.stats.stats.SPD - opponent.stats.stats.SPD;
       const grazeReduction = Math.min(Math.max(spdDiff / 100, 0), 1);
+      const spdDiffPrinted = Math.round((spdDiff) * 100) / 100;
 
       const roll = Rolls.rollD100();
-      messageCache.push(`### **SPD diff**: ${spdDiff}`, TCGThread.Gameroom);
+      messageCache.push(`### **SPD diff**: ${spdDiffPrinted}`, TCGThread.Gameroom);
       messageCache.push(`### Roll: ${roll}`, TCGThread.Gameroom);
 
       const evasionReduction =


### PR DESCRIPTION
For when you make the decision to round the speed diff or not. Actual calculation value is the same, but printed value is rounded.