### PR TITLE
Ban system improvements

### DIFF
--- a/src/commands/tcgStats/statsHandlers/banRates.ts
+++ b/src/commands/tcgStats/statsHandlers/banRates.ts
@@ -21,25 +21,27 @@ export default async function handleBanRates(
     match: rankedMatchWhere,
   } as const;
 
-  const [totalRankedMatches, distinctMatchIds, groupedBans] = await Promise.all([
-    prismaClient.match.count({
-      where: rankedMatchWhere,
-    }),
-    prismaClient.characterBan.findMany({
-      where: characterBanWhere,
-      distinct: ["matchId"],
-      select: {
-        matchId: true,
-      },
-    }),
-    prismaClient.characterBan.groupBy({
-      by: ["characterId"],
-      _count: {
-        characterId: true,
-      },
-      where: characterBanWhere,
-    }),
-  ]);
+  const [totalRankedMatches, distinctMatchIds, groupedBans] = await Promise.all(
+    [
+      prismaClient.match.count({
+        where: rankedMatchWhere,
+      }),
+      prismaClient.characterBan.findMany({
+        where: characterBanWhere,
+        distinct: ["matchId"],
+        select: {
+          matchId: true,
+        },
+      }),
+      prismaClient.characterBan.groupBy({
+        by: ["characterId"],
+        _count: {
+          characterId: true,
+        },
+        where: characterBanWhere,
+      }),
+    ]
+  );
 
   const totalMatchesWithBans = distinctMatchIds.length;
   const rankedMatchesWithoutBans = Math.max(

--- a/src/commands/tcgStats/statsHandlers/banRates.ts
+++ b/src/commands/tcgStats/statsHandlers/banRates.ts
@@ -12,14 +12,19 @@ export default async function handleBanRates(
     ? await querySeason(seasonId)
     : null;
 
-  const characterBanWhere = {
-    match: {
-      ranked: true,
-      ladderReset: seasonFilter ?? { endDate: null },
-    },
+  const rankedMatchWhere = {
+    ranked: true,
+    ladderReset: seasonFilter ?? { endDate: null },
   } as const;
 
-  const [distinctMatchIds, groupedBans] = await Promise.all([
+  const characterBanWhere = {
+    match: rankedMatchWhere,
+  } as const;
+
+  const [totalRankedMatches, distinctMatchIds, groupedBans] = await Promise.all([
+    prismaClient.match.count({
+      where: rankedMatchWhere,
+    }),
     prismaClient.characterBan.findMany({
       where: characterBanWhere,
       distinct: ["matchId"],
@@ -37,10 +42,17 @@ export default async function handleBanRates(
   ]);
 
   const totalMatchesWithBans = distinctMatchIds.length;
+  const rankedMatchesWithoutBans = Math.max(
+    totalRankedMatches - totalMatchesWithBans,
+    0
+  );
 
   if (totalMatchesWithBans === 0) {
+    const noDataMessage = rankedMatchesWithoutBans
+      ? `No bans were recorded for this season. Ranked matches without bans: ${rankedMatchesWithoutBans}`
+      : "No ranked ban data available.";
     await interaction.editReply({
-      content: "No ranked ban data available yet.",
+      content: noDataMessage,
     });
     return;
   }
@@ -85,7 +97,7 @@ export default async function handleBanRates(
     .setTitle("Ranked Ban Rates")
     .setDescription(description)
     .setFooter({
-      text: `Total ranked matches with bans: ${totalMatchesWithBans}`,
+      text: `Total ranked matches with bans: ${totalMatchesWithBans}\nRanked matches without bans: ${rankedMatchesWithoutBans}`,
     });
 
   await interaction.editReply({

--- a/src/tcgMain.ts
+++ b/src/tcgMain.ts
@@ -89,8 +89,8 @@ export const tcgMain = async (
   if (bansPerPlayer > 0) {
     const banPhaseIntro =
       bansPerPlayer === 1
-        ? "⭕ Ban phase started! Each player may ban 1 character."
-        : `⭕ Ban phase started! Each player may ban ${bansPerPlayer} characters.`;
+        ? "🔴 Ban phase started! Each player may ban 1 character."
+        : `🔴 Ban phase started! Each player may ban ${bansPerPlayer} characters.`;
     messageCache.push(`## ${banPhaseIntro}`, TCGThread.Gameroom);
     await sendToThread(
       messageCache.flush(TCGThread.Gameroom),
@@ -121,6 +121,32 @@ export const tcgMain = async (
       messageCache.push(`## ${announcement}`, TCGThread.Gameroom);
       messageCache.push(`## ${announcement}`, TCGThread.ChallengerThread);
       messageCache.push(`## ${announcement}`, TCGThread.OpponentThread);
+
+      await Promise.all([
+        sendToThread(
+          messageCache.flush(TCGThread.Gameroom),
+          TCGThread.Gameroom,
+          threadsMapping,
+          textSpeedMs
+        ),
+        sendToThread(
+          messageCache.flush(TCGThread.ChallengerThread),
+          TCGThread.ChallengerThread,
+          threadsMapping,
+          Math.max(200, textSpeedMs / 2)
+        ),
+        sendToThread(
+          messageCache.flush(TCGThread.OpponentThread),
+          TCGThread.OpponentThread,
+          threadsMapping,
+          Math.max(200, textSpeedMs / 2)
+        ),
+      ]);
+    } else {
+      const noBanMessage = "🟢 No characters were banned this match.";
+      messageCache.push(`## ${noBanMessage}`, TCGThread.Gameroom);
+      messageCache.push(`## ${noBanMessage}`, TCGThread.ChallengerThread);
+      messageCache.push(`## ${noBanMessage}`, TCGThread.OpponentThread);
 
       await Promise.all([
         sendToThread(


### PR DESCRIPTION
- added a "No characters were banned this match" announcement when both players skip the ban phase
- enhanced `/tcg-stats ban-rates` to show the number of ranked matches without bans, and clarified the no-data message
- some minor changes